### PR TITLE
Add local file transcription CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,3 +110,13 @@ The response will be a JSON object containing the transcribed text:
   "transcription": "This is the transcribed text from the audio."
 }
 ```
+
+## Transcribing Local Files
+
+You can also transcribe a local audio file directly from the command line. First ensure your `.env` file contains your ElevenLabs credentials, then run:
+
+```bash
+npm run transcribe -- path/to/audio.wav
+```
+
+Replace `path/to/audio.wav` with the path to your audio file. The transcription text will be printed to the console.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "start": "node .",
     "start:dev": "nodemon --inspect ./index.js",
     "dc:build": "docker build --platform=linux/amd64 -t agentvoiceresponse/avr-stt-elevenlabs:latest -t agentvoiceresponse/avr-stt-elevenlabs:${npm_package_version} .",
-    "dc:push": "docker push agentvoiceresponse/avr-stt-elevenlabs:latest && docker push agentvoiceresponse/avr-stt-elevenlabs:${npm_package_version}"
+    "dc:push": "docker push agentvoiceresponse/avr-stt-elevenlabs:latest && docker push agentvoiceresponse/avr-stt-elevenlabs:${npm_package_version}",
+    "transcribe": "node transcribe-file.js"
   },
   "dependencies": {
     "dotenv": "^16.4.7",

--- a/transcribe-file.js
+++ b/transcribe-file.js
@@ -1,0 +1,35 @@
+const fs = require('fs');
+const path = require('path');
+const { ElevenLabsClient } = require('elevenlabs');
+require('dotenv').config();
+
+(async () => {
+  const filePath = process.argv[2];
+  if (!filePath) {
+    console.error('Usage: node transcribe-file.js <audio-file-path>');
+    process.exit(1);
+  }
+
+  const resolvedPath = path.resolve(filePath);
+  if (!fs.existsSync(resolvedPath)) {
+    console.error(`File not found: ${resolvedPath}`);
+    process.exit(1);
+  }
+
+  try {
+    const client = new ElevenLabsClient({ apiKey: process.env.ELEVENLABS_API_KEY });
+    const modelId = process.env.ELEVENLABS_MODEL_ID || 'scribe_v1';
+
+    const transcription = await client.speechToText.convert({
+      file: fs.createReadStream(resolvedPath),
+      model_id: modelId,
+      file_format: 'other'
+    });
+
+    console.log(transcription.text || '');
+  } catch (err) {
+    console.error('Error transcribing file:', err.message || err);
+    process.exit(1);
+  }
+})();
+


### PR DESCRIPTION
## Summary
- add `transcribe-file.js` to transcribe a local audio file
- expose new npm script `transcribe`
- document how to transcribe local audio files

## Testing
- `node --check transcribe-file.js`
- `node --check index.js`
- `node -e "require('./package.json'); console.log('package loaded');"`

------
https://chatgpt.com/codex/tasks/task_e_684027f122d883209d8fe874289982fa