### PR TITLE
Update transcription options

### DIFF
--- a/transcribe-file.js
+++ b/transcribe-file.js
@@ -23,7 +23,11 @@ require('dotenv').config();
     const transcription = await client.speechToText.convert({
       file: fs.createReadStream(resolvedPath),
       model_id: modelId,
-      file_format: 'other'
+      file_format: 'other',
+      language_code: process.env.ELEVENLABS_LANGUAGE_CODE || 'uk',
+      num_speakers: Number(process.env.ELEVENLABS_NUM_SPEAKERS || 2),
+      tag_audio_events: false,
+      diarize: true
     });
 
     console.log(transcription.text || '');


### PR DESCRIPTION
## Summary
- allow customizing language and speaker count in `transcribe-file.js`
- enable diarization and disable audio events tagging

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68402fe4ca7483209310e743ea1efee8