### PR TITLE
Add output file option for transcription

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ The response will be a JSON object containing the transcribed text:
 You can also transcribe a local audio file directly from the command line. First ensure your `.env` file contains your ElevenLabs credentials, then run:
 
 ```bash
-npm run transcribe -- path/to/audio.wav
+npm run transcribe -- path/to/audio.wav [output.txt]
 ```
 
-Replace `path/to/audio.wav` with the path to your audio file. The transcription text will be printed to the console.
+Replace `path/to/audio.wav` with the path to your audio file. Optionally specify an `output.txt` path to save the speaker-labelled transcript; otherwise it will be printed to the console.

--- a/transcribe-file.js
+++ b/transcribe-file.js
@@ -5,8 +5,9 @@ require('dotenv').config();
 
 (async () => {
   const filePath = process.argv[2];
+  const outputPath = process.argv[3];
   if (!filePath) {
-    console.error('Usage: node transcribe-file.js <audio-file-path>');
+    console.error('Usage: node transcribe-file.js <audio-file-path> [output-file]');
     process.exit(1);
   }
 
@@ -21,15 +22,41 @@ require('dotenv').config();
     const modelId = process.env.ELEVENLABS_MODEL_ID || 'scribe_v1';
 
     const transcription = await client.speechToText.convert({
-		file: fs.createReadStream(resolvedPath),
-		model_id: modelId,
-		file_format: "other",
-		language_code: process.env.ELEVENLABS_LANGUAGE_CODE || "uk",
-		tag_audio_events: false,
-		diarize: true,
-	});
+                file: fs.createReadStream(resolvedPath),
+                model_id: modelId,
+                file_format: "other",
+                language_code: process.env.ELEVENLABS_LANGUAGE_CODE || "uk",
+                tag_audio_events: false,
+                diarize: true,
+        });
 
-    console.log(transcription.text || '');
+    let output = '';
+    if (Array.isArray(transcription.words) && transcription.words.length > 0) {
+      const segments = [];
+      let currentSpeaker = transcription.words[0].speaker_id || '0';
+      let buffer = [];
+      for (const word of transcription.words) {
+        const speaker = word.speaker_id || '0';
+        if (speaker !== currentSpeaker) {
+          segments.push({ speaker: currentSpeaker, text: buffer.join(' ') });
+          currentSpeaker = speaker;
+          buffer = [];
+        }
+        buffer.push(word.text);
+      }
+      if (buffer.length > 0) {
+        segments.push({ speaker: currentSpeaker, text: buffer.join(' ') });
+      }
+      output = segments.map(seg => `[Speaker ${seg.speaker}]\n${seg.text}`).join('\n\n');
+    } else {
+      output = transcription.text || '';
+    }
+
+    if (outputPath) {
+      fs.writeFileSync(path.resolve(outputPath), output, 'utf8');
+    } else {
+      console.log(output);
+    }
   } catch (err) {
     console.error('Error transcribing file:', err.message || err);
     process.exit(1);


### PR DESCRIPTION
## Summary
- extend `transcribe-file.js` to write diarized output to an optional file
- update README usage example

## Testing
- `node transcribe-file.js` *(fails: Cannot find module 'elevenlabs')*

------
https://chatgpt.com/codex/tasks/task_e_68404d119994832094c9a72df723cc6e